### PR TITLE
chore: Update package metadata for publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,9 @@ jobs:
           sudo apt install -y build-essential cmake pkg-config libudev-dev
 
       - name: Install SP1
-        uses: nitro-svm/infrastructure/actions/install-sp1@main
+        run: |
+          curl -L https://sp1up.succinct.xyz | bash
+          $HOME/.sp1/bin/sp1up -t $GITHUB_TOKEN -c
 
       - name: Install zepter, just and protoc
         uses: taiki-e/install-action@v2
@@ -155,7 +157,9 @@ jobs:
           echo "$HOME/.avm/bin" >> "$GITHUB_PATH"
 
       - name: Install SP1
-        uses: nitro-svm/infrastructure/actions/install-sp1@main
+        run: |
+          curl -L https://sp1up.succinct.xyz | bash
+          $HOME/.sp1/bin/sp1up -t $GITHUB_TOKEN -c
 
       - name: Run nextest
         run: just test
@@ -236,7 +240,9 @@ jobs:
           echo "$HOME/.avm/bin" >> "$GITHUB_PATH"
 
       - name: Install SP1
-        uses: nitro-svm/infrastructure/actions/install-sp1@main
+        run: |
+          curl -L https://sp1up.succinct.xyz | bash
+          $HOME/.sp1/bin/sp1up -t $GITHUB_TOKEN -c
 
       - name: Run program tests
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anchor-lang",
  "bytesize",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-api"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-blober"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anchor-lang",
  "arbitrary",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-data-correctness"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "data-anchor-prover-core",
  "sp1-zkvm 5.2.1",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-data-correctness-verifier"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anchor-lang",
  "data-anchor-blober",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-encoding-compression-test"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "data-anchor-prover-core",
  "data-anchor-utils",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-examples"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap 4.5.47",
  "data-anchor-client",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-pob-sla"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "data-anchor-prover-core",
  "sp1-zkvm 5.2.1",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-pob-sla-verifier"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-proofs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anchor-lang",
  "arbitrary",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-prover"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "data-anchor-api",
  "data-anchor-proofs",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-prover-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "data-anchor-proofs",
  "sp1-derive",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-prover-script"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anchor-lang",
  "arbitrary",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-utils"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["programs"]
 
 [workspace.package]
 edition = "2024"
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT"
 authors = ["Nitro Labs <team@nitro.technology>"]
 homepage = "https://www.termina.technology"
@@ -90,22 +90,22 @@ sp1-zkvm = "5.2.1"
 nitro-sender = "0.2.0"
 
 # Locals
-data-anchor = { path = "crates/cli", version = "0.4.2" }
-data-anchor-api = { path = "crates/indexer-api", version = "0.4.2" }
-data-anchor-client = { path = "crates/client", version = "0.4.2" }
-data-anchor-proofs = { path = "crates/proofs", version = "0.4.2" }
-data-anchor-blober = { path = "programs/programs/blober", version = "0.2.1", default-features = false, features = [
+data-anchor = { path = "crates/cli", version = "0.4.3" }
+data-anchor-api = { path = "crates/indexer-api", version = "0.4.3" }
+data-anchor-client = { path = "crates/client", version = "0.4.3" }
+data-anchor-proofs = { path = "crates/proofs", version = "0.4.3" }
+data-anchor-blober = { path = "programs/programs/blober", version = "0.2.2", default-features = false, features = [
   "no-entrypoint",
 ] }
-data-anchor-data-correctness-verifier = { path = "programs/programs/data-correctness", version = "0.2.1", default-features = false, features = [
+data-anchor-data-correctness-verifier = { path = "programs/programs/data-correctness", version = "0.2.2", default-features = false, features = [
   "no-entrypoint",
 ] }
-data-anchor-pob-sla-verifier = { path = "programs/programs/pob-sla", version = "0.2.1", default-features = false, features = [
+data-anchor-pob-sla-verifier = { path = "programs/programs/pob-sla", version = "0.2.2", default-features = false, features = [
   "no-entrypoint",
 ] }
 data-anchor-prover = { path = "crates/prover" }
 data-anchor-prover-core = { path = "crates/prover/programs/core" }
-data-anchor-utils = { path = "crates/utils", version = "0.4.2" }
+data-anchor-utils = { path = "crates/utils", version = "0.4.3" }
 
 [patch.crates-io]
 getrandom_v0_1 = { package = "getrandom", git = "https://github.com/nitro-svm/getrandom", branch = "0.1-zkvm" }

--- a/README.md
+++ b/README.md
@@ -5,86 +5,82 @@
 </div>
 
 ### TL;DR
-Data Anchor delivers on‑chain verifiable storage at a fraction of the cost.
 
+Data Anchor delivers on‑chain verifiable storage at a fraction of the cost.
 
 ## Introduction
 
-Data Anchor lets you store your data blobs on Solana’s ledger—packed and fully verifiable—while keeping costs low via efficient storage and an indexer. You pay rent once per blob, fetch data instantly via HTTP or CLI, and enjoy order‑of‑magnitude savings over naïvely stuffing bytes into on‑chain accounts 
-
+Data Anchor lets you store your data blobs on Solana’s ledger—packed and fully verifiable—while keeping costs low via efficient storage and an indexer. You pay rent once per blob, fetch data instantly via HTTP or CLI, and enjoy order‑of‑magnitude savings over naïvely stuffing bytes into on‑chain accounts
 
 ## Quickstart
 
 **Usage**
+
 - [CLI Usage](https://github.com/nitro-svm/examples/tree/main/anchoring-data/cli)
 - [Client Usage](https://github.com/nitro-svm/examples/tree/main/anchoring-data/client)
 
 **Video Demos**
 
 1. [Uploading and Verifying Data on Solana](https://youtu.be/sgjmaujHYdE?si=a4GJrxBX5B24HHvF)
-2. [Upload and Index Data on Solana](https://youtu.be/sgjmaujHYdE?si=a4GJrxBX5B24HHvF)
-
+1. [Upload and Index Data on Solana](https://youtu.be/sgjmaujHYdE?si=a4GJrxBX5B24HHvF)
 
 ## Why use Data Anchor
 
-- **Minimized rent costs**: Storing data directly on Solana can cost ≈6.96 SOL per MB annually (rent‑exempt deposit), Data Anchor amortizes rent across data blobs to deliver over 100,000× savings. 
+- **Minimized rent costs**: Storing data directly on Solana can cost ≈6.96 SOL per MB annually (rent‑exempt deposit), Data Anchor amortizes rent across data blobs to deliver over 100,000× savings.
 
-- **Handles arbitrary data**: Supports any payload—IoT metrics or availability proofs, ideal for data‑intensive DePIN networks generating millions of inputs per minute. 
+- **Handles arbitrary data**: Supports any payload—IoT metrics or availability proofs, ideal for data‑intensive DePIN networks generating millions of inputs per minute.
 
 - **Efficient ledger usage**: By packing data blobs into Solana’s append‑only ledger history where storage is cheaper than accounts, Data Anchor retains only minimal commitments in account space.
 
 - **Instant retrieval**: Anchored blobs can be fetched in their original JSON form with no manual reassembly, removing the overhead of reconstructing data from raw transactions.
 
-- **Immutable, verifiable data**: Every blob lives onchain, giving you cryptographic proof of integrity that can be independently audited against Solana’s tamper‑proof ledger. 
+- **Immutable, verifiable data**: Every blob lives onchain, giving you cryptographic proof of integrity that can be independently audited against Solana’s tamper‑proof ledger.
 
 - **Built for scale**: Data Anchor leverages Solana’s high throughput (up to ~1,289 TPS) and sub‑second block times (≈0.4 s).
-
 
 ## Architecture
 
 We built Data Anchor as a set of focused Rust crates for anchoring data, on‑chain interaction, indexing, and proof handling—so teams can pick only the pieces they need. This modular design powers DePIN networks, rollups, and data‑heavy dApps seeking verifiable, scalable storage.
 
-
 ## Examples Overview
 
 A quick run‑through of core workflows—see the CLI or RPC docs for full commands:
 
-* **Initialize Namespace**
+- **Initialize Namespace**
   Create a new blober PDA for your namespace.
 
-* **Upload Data**
+- **Upload Data**
   Store a JSON file as an on‑chain blob.
 
-* **Fetch & Decode Blob**
+- **Fetch & Decode Blob**
   Retrieve by signature and decode the hex‑encoded data back into JSON.
 
-* **get\_blobs\_by\_namespace**
+- **get_blobs_by_namespace**
   List all blobs under your namespace via the indexer.
 
-* **get\_blobs\_by\_payer**
+- **get_blobs_by_payer**
   List blobs paid for by your wallet.
 
-* **get\_blobs**
+- **get_blobs**
   Fetch a specific blob by PDA and slot.
 
-* **get\_payers\_by\_network**
+- **get_payers_by_network**
   List all payers on a given network.
 
-* **get\_proof**
+- **get_proof**
   Obtain a cryptographic proof for a blob.
 
-
 ## Full API reference and integration guides
+
 [Data Anchor Developer Documentation](https://docs.termina.technology/documentation/network-extension-stack/modules/data-anchor)
 
 #### Data Anchor Crate Documentations
 
-* [CLI Documentation](https://docs.rs/data-anchor/latest/data_anchor/)
-* [Client API](https://docs.rs/data-anchor-client/latest/data_anchor_client/)
-* [Blober Program](https://docs.rs/data-anchor-blober/latest/data_anchor_blober/)
-* [Indexer API](https://docs.rs/data-anchor-api/latest/data_anchor_api/)
-* [Proofs API](https://docs.rs/data-anchor-proofs/latest/data_anchor_proofs/)
-
+- [CLI Documentation](https://docs.rs/data-anchor-oss/latest/data_anchor/)
+- [Client API](https://docs.rs/data-anchor-client/latest/data_anchor_client/)
+- [Blober Program](https://docs.rs/data-anchor-blober/latest/data_anchor_blober/)
+- [Indexer API](https://docs.rs/data-anchor-api/latest/data_anchor_api/)
+- [Proofs API](https://docs.rs/data-anchor-proofs/latest/data_anchor_proofs/)
 
 ## Support
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,84 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.4.1...data-anchor-v0.4.2) - 2025-08-27
+## [0.4.2](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-v0.4.1...data-anchor-v0.4.2) - 2025-08-27
 
 ### Added
 
-- Add verifier alias instead of pubkey for checkpoint authority ([#345](https://github.com/nitro-svm/data-anchor/pull/345))
-- Add default indexer URL and recognition based on RPC URL ([#338](https://github.com/nitro-svm/data-anchor/pull/338))
-- Add encoding and compression markers to data ([#337](https://github.com/nitro-svm/data-anchor/pull/337))
+- Add verifier alias instead of pubkey for checkpoint authority ([#345](https://github.com/nitro-svm/data-anchor-oss/pull/345))
+- Add default indexer URL and recognition based on RPC URL ([#338](https://github.com/nitro-svm/data-anchor-oss/pull/338))
+- Add encoding and compression markers to data ([#337](https://github.com/nitro-svm/data-anchor-oss/pull/337))
 
 ### Fixed
 
-- Increase wait time for fallback ([#335](https://github.com/nitro-svm/data-anchor/pull/335))
+- Increase wait time for fallback ([#335](https://github.com/nitro-svm/data-anchor-oss/pull/335))
 
 ### Other
 
-- Clean up CLI and improve client constants ([#352](https://github.com/nitro-svm/data-anchor/pull/352))
-- Improve CLI output for ZK proof request ([#348](https://github.com/nitro-svm/data-anchor/pull/348))
+- Clean up CLI and improve client constants ([#352](https://github.com/nitro-svm/data-anchor-oss/pull/352))
+- Improve CLI output for ZK proof request ([#348](https://github.com/nitro-svm/data-anchor-oss/pull/348))
 
-## [0.4.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.4.0...data-anchor-v0.4.1) - 2025-08-19
+## [0.4.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-v0.4.0...data-anchor-v0.4.1) - 2025-08-19
 
 ### Added
 
-- Add SP1 support for compression ([#326](https://github.com/nitro-svm/data-anchor/pull/326))
-- Add compression support to client ([#315](https://github.com/nitro-svm/data-anchor/pull/315))
-- Add encoding support to client ([#314](https://github.com/nitro-svm/data-anchor/pull/314))
-- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor/pull/308))
-- Add proof request status query ([#305](https://github.com/nitro-svm/data-anchor/pull/305))
-- Add proof posting on-chain after ZK generation ([#303](https://github.com/nitro-svm/data-anchor/pull/303))
-- Add verifiers and improve checkpointing ([#294](https://github.com/nitro-svm/data-anchor/pull/294))
-- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor/pull/281))
-- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor/pull/268))
-- Use vanity address for blober program ([#266](https://github.com/nitro-svm/data-anchor/pull/266))
+- Add SP1 support for compression ([#326](https://github.com/nitro-svm/data-anchor-oss/pull/326))
+- Add compression support to client ([#315](https://github.com/nitro-svm/data-anchor-oss/pull/315))
+- Add encoding support to client ([#314](https://github.com/nitro-svm/data-anchor-oss/pull/314))
+- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor-oss/pull/308))
+- Add proof request status query ([#305](https://github.com/nitro-svm/data-anchor-oss/pull/305))
+- Add proof posting on-chain after ZK generation ([#303](https://github.com/nitro-svm/data-anchor-oss/pull/303))
+- Add verifiers and improve checkpointing ([#294](https://github.com/nitro-svm/data-anchor-oss/pull/294))
+- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor-oss/pull/281))
+- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor-oss/pull/268))
+- Use vanity address for blober program ([#266](https://github.com/nitro-svm/data-anchor-oss/pull/266))
 
 ### Other
 
-- Benchmark cleanup ([#312](https://github.com/nitro-svm/data-anchor/pull/312))
-- Add list payers command and improve e2e script ([#306](https://github.com/nitro-svm/data-anchor/pull/306))
-- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor/pull/302))
-- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor/pull/301))
-- Use solana_clock instead of solana_sdk Slot import ([#300](https://github.com/nitro-svm/data-anchor/pull/300))
-- Use solana_signer instead of solana_sdk Signer import ([#298](https://github.com/nitro-svm/data-anchor/pull/298))
-- Use solana_keypair instead of solana_sdk Keypair import ([#297](https://github.com/nitro-svm/data-anchor/pull/297))
-- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor/pull/296))
-- Make time range param consistently optional ([#283](https://github.com/nitro-svm/data-anchor/pull/283))
+- Benchmark cleanup ([#312](https://github.com/nitro-svm/data-anchor-oss/pull/312))
+- Add list payers command and improve e2e script ([#306](https://github.com/nitro-svm/data-anchor-oss/pull/306))
+- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor-oss/pull/302))
+- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor-oss/pull/301))
+- Use solana_clock instead of solana_sdk Slot import ([#300](https://github.com/nitro-svm/data-anchor-oss/pull/300))
+- Use solana_signer instead of solana_sdk Signer import ([#298](https://github.com/nitro-svm/data-anchor-oss/pull/298))
+- Use solana_keypair instead of solana_sdk Keypair import ([#297](https://github.com/nitro-svm/data-anchor-oss/pull/297))
+- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor-oss/pull/296))
+- Make time range param consistently optional ([#283](https://github.com/nitro-svm/data-anchor-oss/pull/283))
 
-## [0.4.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.3.1...data-anchor-v0.4.0) - 2025-07-10
+## [0.4.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-v0.3.1...data-anchor-v0.4.0) - 2025-07-10
 
 ### Added
 
-- Add balance and account existance checks for on-chain commands ([#261](https://github.com/nitro-svm/data-anchor/pull/261))
-- Improve PDA management and outputs ([#241](https://github.com/nitro-svm/data-anchor/pull/241))
-- Add blober PDA pubkey to command output ([#239](https://github.com/nitro-svm/data-anchor/pull/239))
-- Improve CLI README.md ([#236](https://github.com/nitro-svm/data-anchor/pull/236))
-- Improve client and CLI ergonomics ([#235](https://github.com/nitro-svm/data-anchor/pull/235))
-- Improve CLI integration ([#234](https://github.com/nitro-svm/data-anchor/pull/234))
+- Add balance and account existance checks for on-chain commands ([#261](https://github.com/nitro-svm/data-anchor-oss/pull/261))
+- Improve PDA management and outputs ([#241](https://github.com/nitro-svm/data-anchor-oss/pull/241))
+- Add blober PDA pubkey to command output ([#239](https://github.com/nitro-svm/data-anchor-oss/pull/239))
+- Improve CLI README.md ([#236](https://github.com/nitro-svm/data-anchor-oss/pull/236))
+- Improve client and CLI ergonomics ([#235](https://github.com/nitro-svm/data-anchor-oss/pull/235))
+- Improve CLI integration ([#234](https://github.com/nitro-svm/data-anchor-oss/pull/234))
 
 ### Fixed
 
-- Add full e2e test and squash discovered bugs ([#257](https://github.com/nitro-svm/data-anchor/pull/257))
-- Serialize blober identifier in parent struct and streamline identifier on CLI level ([#244](https://github.com/nitro-svm/data-anchor/pull/244))
+- Add full e2e test and squash discovered bugs ([#257](https://github.com/nitro-svm/data-anchor-oss/pull/257))
+- Serialize blober identifier in parent struct and streamline identifier on CLI level ([#244](https://github.com/nitro-svm/data-anchor-oss/pull/244))
 
 ### Other
 
-- Also use `BloberIdentifier` on initialization ([#260](https://github.com/nitro-svm/data-anchor/pull/260))
-- Simplify API params on indexer RPC ([#228](https://github.com/nitro-svm/data-anchor/pull/228))
+- Also use `BloberIdentifier` on initialization ([#260](https://github.com/nitro-svm/data-anchor-oss/pull/260))
+- Simplify API params on indexer RPC ([#228](https://github.com/nitro-svm/data-anchor-oss/pull/228))
 
-## [0.3.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.2.0...data-anchor-v0.3.0) - 2025-06-26
+## [0.3.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-v0.2.0...data-anchor-v0.3.0) - 2025-06-26
 
 ### Added
 
-- Add `payer_pubkey` to namespace query ([#203](https://github.com/nitro-svm/data-anchor/pull/203))
-- Rename `BloberClient` to `DataAnchorClient` ([#202](https://github.com/nitro-svm/data-anchor/pull/202))
-- Add API key support to blober client and CLI ([#201](https://github.com/nitro-svm/data-anchor/pull/201))
-- Add new methods to anchor CLI ([#200](https://github.com/nitro-svm/data-anchor/pull/200))
-- Add new methods to blober client ([#199](https://github.com/nitro-svm/data-anchor/pull/199))
+- Add `payer_pubkey` to namespace query ([#203](https://github.com/nitro-svm/data-anchor-oss/pull/203))
+- Rename `BloberClient` to `DataAnchorClient` ([#202](https://github.com/nitro-svm/data-anchor-oss/pull/202))
+- Add API key support to blober client and CLI ([#201](https://github.com/nitro-svm/data-anchor-oss/pull/201))
+- Add new methods to anchor CLI ([#200](https://github.com/nitro-svm/data-anchor-oss/pull/200))
+- Add new methods to blober client ([#199](https://github.com/nitro-svm/data-anchor-oss/pull/199))
 
 ### Other
 
-- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor/pull/211))
+- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor-oss/pull/211))
 
 ## [0.1.7](https://github.com/nitro-svm/nitro-data-module/compare/nitro-da-cli-v0.1.6...nitro-da-cli-v0.1.7) - 2025-05-30
 

--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -7,101 +7,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.4.1...data-anchor-client-v0.4.2) - 2025-08-27
+## [0.4.2](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-client-v0.4.1...data-anchor-client-v0.4.2) - 2025-08-27
 
 ### Added
 
-- Add `set_loaded_account_data_size_limit` instruction to transactions ([#350](https://github.com/nitro-svm/data-anchor/pull/350))
-- Add default indexer URL and recognition based on RPC URL ([#338](https://github.com/nitro-svm/data-anchor/pull/338))
-- Add encoding and compression markers to data ([#337](https://github.com/nitro-svm/data-anchor/pull/337))
+- Add `set_loaded_account_data_size_limit` instruction to transactions ([#350](https://github.com/nitro-svm/data-anchor-oss/pull/350))
+- Add default indexer URL and recognition based on RPC URL ([#338](https://github.com/nitro-svm/data-anchor-oss/pull/338))
+- Add encoding and compression markers to data ([#337](https://github.com/nitro-svm/data-anchor-oss/pull/337))
 
 ### Other
 
-- Clean up CLI and improve client constants ([#352](https://github.com/nitro-svm/data-anchor/pull/352))
-- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor/pull/344))
-- Enhance logging for transaction processing and blob operations ([#343](https://github.com/nitro-svm/data-anchor/pull/343))
+- Clean up CLI and improve client constants ([#352](https://github.com/nitro-svm/data-anchor-oss/pull/352))
+- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor-oss/pull/344))
+- Enhance logging for transaction processing and blob operations ([#343](https://github.com/nitro-svm/data-anchor-oss/pull/343))
 
-## [0.4.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.4.0...data-anchor-client-v0.4.1) - 2025-08-19
+## [0.4.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-client-v0.4.0...data-anchor-client-v0.4.1) - 2025-08-19
 
 ### Added
 
-- Add SP1 support for compression ([#326](https://github.com/nitro-svm/data-anchor/pull/326))
-- Add compression support to client ([#315](https://github.com/nitro-svm/data-anchor/pull/315))
-- Add encoding support to client ([#314](https://github.com/nitro-svm/data-anchor/pull/314))
-- Add foot-gun protection against early blober closing ([#310](https://github.com/nitro-svm/data-anchor/pull/310))
-- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor/pull/308))
-- Add proof request status query ([#305](https://github.com/nitro-svm/data-anchor/pull/305))
-- Add proof posting on-chain after ZK generation ([#303](https://github.com/nitro-svm/data-anchor/pull/303))
-- Add verifiers and improve checkpointing ([#294](https://github.com/nitro-svm/data-anchor/pull/294))
-- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor/pull/281))
-- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor/pull/268))
-- Use vanity address for blober program ([#266](https://github.com/nitro-svm/data-anchor/pull/266))
+- Add SP1 support for compression ([#326](https://github.com/nitro-svm/data-anchor-oss/pull/326))
+- Add compression support to client ([#315](https://github.com/nitro-svm/data-anchor-oss/pull/315))
+- Add encoding support to client ([#314](https://github.com/nitro-svm/data-anchor-oss/pull/314))
+- Add foot-gun protection against early blober closing ([#310](https://github.com/nitro-svm/data-anchor-oss/pull/310))
+- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor-oss/pull/308))
+- Add proof request status query ([#305](https://github.com/nitro-svm/data-anchor-oss/pull/305))
+- Add proof posting on-chain after ZK generation ([#303](https://github.com/nitro-svm/data-anchor-oss/pull/303))
+- Add verifiers and improve checkpointing ([#294](https://github.com/nitro-svm/data-anchor-oss/pull/294))
+- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor-oss/pull/281))
+- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor-oss/pull/268))
+- Use vanity address for blober program ([#266](https://github.com/nitro-svm/data-anchor-oss/pull/266))
 
 ### Fixed
 
-- Remove memcmp filter ([#330](https://github.com/nitro-svm/data-anchor/pull/330))
-- Swap cost and balance in error enum ([#288](https://github.com/nitro-svm/data-anchor/pull/288))
+- Remove memcmp filter ([#330](https://github.com/nitro-svm/data-anchor-oss/pull/330))
+- Swap cost and balance in error enum ([#288](https://github.com/nitro-svm/data-anchor-oss/pull/288))
 
 ### Other
 
-- Use `sp1-solana` from crates.io ([#332](https://github.com/nitro-svm/data-anchor/pull/332))
-- Benchmark cleanup ([#312](https://github.com/nitro-svm/data-anchor/pull/312))
-- Add list payers command and improve e2e script ([#306](https://github.com/nitro-svm/data-anchor/pull/306))
-- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor/pull/302))
-- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor/pull/301))
-- Use solana_clock instead of solana_sdk Slot import ([#300](https://github.com/nitro-svm/data-anchor/pull/300))
-- Use solana_transaction instead of solana_sdk Transaction import ([#299](https://github.com/nitro-svm/data-anchor/pull/299))
-- Use solana_signer instead of solana_sdk Signer import ([#298](https://github.com/nitro-svm/data-anchor/pull/298))
-- Use solana_keypair instead of solana_sdk Keypair import ([#297](https://github.com/nitro-svm/data-anchor/pull/297))
-- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor/pull/296))
-- Make time range param consistently optional ([#283](https://github.com/nitro-svm/data-anchor/pull/283))
+- Use `sp1-solana` from crates.io ([#332](https://github.com/nitro-svm/data-anchor-oss/pull/332))
+- Benchmark cleanup ([#312](https://github.com/nitro-svm/data-anchor-oss/pull/312))
+- Add list payers command and improve e2e script ([#306](https://github.com/nitro-svm/data-anchor-oss/pull/306))
+- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor-oss/pull/302))
+- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor-oss/pull/301))
+- Use solana_clock instead of solana_sdk Slot import ([#300](https://github.com/nitro-svm/data-anchor-oss/pull/300))
+- Use solana_transaction instead of solana_sdk Transaction import ([#299](https://github.com/nitro-svm/data-anchor-oss/pull/299))
+- Use solana_signer instead of solana_sdk Signer import ([#298](https://github.com/nitro-svm/data-anchor-oss/pull/298))
+- Use solana_keypair instead of solana_sdk Keypair import ([#297](https://github.com/nitro-svm/data-anchor-oss/pull/297))
+- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor-oss/pull/296))
+- Make time range param consistently optional ([#283](https://github.com/nitro-svm/data-anchor-oss/pull/283))
 
-## [0.4.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.3.1...data-anchor-client-v0.4.0) - 2025-07-10
+## [0.4.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-client-v0.3.1...data-anchor-client-v0.4.0) - 2025-07-10
 
 ### Added
 
-- Add balance and account existance checks for on-chain commands ([#261](https://github.com/nitro-svm/data-anchor/pull/261))
-- Improve PDA management and outputs ([#241](https://github.com/nitro-svm/data-anchor/pull/241))
-- Improve client README.md ([#237](https://github.com/nitro-svm/data-anchor/pull/237))
-- Improve client and CLI ergonomics ([#235](https://github.com/nitro-svm/data-anchor/pull/235))
-- Improve CLI integration ([#234](https://github.com/nitro-svm/data-anchor/pull/234))
+- Add balance and account existance checks for on-chain commands ([#261](https://github.com/nitro-svm/data-anchor-oss/pull/261))
+- Improve PDA management and outputs ([#241](https://github.com/nitro-svm/data-anchor-oss/pull/241))
+- Improve client README.md ([#237](https://github.com/nitro-svm/data-anchor-oss/pull/237))
+- Improve client and CLI ergonomics ([#235](https://github.com/nitro-svm/data-anchor-oss/pull/235))
+- Improve CLI integration ([#234](https://github.com/nitro-svm/data-anchor-oss/pull/234))
 
 ### Fixed
 
-- Add full e2e test and squash discovered bugs ([#257](https://github.com/nitro-svm/data-anchor/pull/257))
-- Add user-agent for client calls to pass WAF protection ([#255](https://github.com/nitro-svm/data-anchor/pull/255))
-- Serialize blober identifier in parent struct and streamline identifier on CLI level ([#244](https://github.com/nitro-svm/data-anchor/pull/244))
-- Explictly set max supported transaction version ([#238](https://github.com/nitro-svm/data-anchor/pull/238))
+- Add full e2e test and squash discovered bugs ([#257](https://github.com/nitro-svm/data-anchor-oss/pull/257))
+- Add user-agent for client calls to pass WAF protection ([#255](https://github.com/nitro-svm/data-anchor-oss/pull/255))
+- Serialize blober identifier in parent struct and streamline identifier on CLI level ([#244](https://github.com/nitro-svm/data-anchor-oss/pull/244))
+- Explictly set max supported transaction version ([#238](https://github.com/nitro-svm/data-anchor-oss/pull/238))
 
 ### Other
 
-- Nicer imports of `Hash` ([#262](https://github.com/nitro-svm/data-anchor/pull/262))
-- Also use `BloberIdentifier` on initialization ([#260](https://github.com/nitro-svm/data-anchor/pull/260))
-- Remove unused `use_helius_fee` param ([#256](https://github.com/nitro-svm/data-anchor/pull/256))
-- Fix typo in error message ([#233](https://github.com/nitro-svm/data-anchor/pull/233))
-- Use `HttpClient` instead of `WsClient` ([#232](https://github.com/nitro-svm/data-anchor/pull/232))
-- Simplify API params on indexer RPC ([#228](https://github.com/nitro-svm/data-anchor/pull/228))
+- Nicer imports of `Hash` ([#262](https://github.com/nitro-svm/data-anchor-oss/pull/262))
+- Also use `BloberIdentifier` on initialization ([#260](https://github.com/nitro-svm/data-anchor-oss/pull/260))
+- Remove unused `use_helius_fee` param ([#256](https://github.com/nitro-svm/data-anchor-oss/pull/256))
+- Fix typo in error message ([#233](https://github.com/nitro-svm/data-anchor-oss/pull/233))
+- Use `HttpClient` instead of `WsClient` ([#232](https://github.com/nitro-svm/data-anchor-oss/pull/232))
+- Simplify API params on indexer RPC ([#228](https://github.com/nitro-svm/data-anchor-oss/pull/228))
 
-## [0.3.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.3.0...data-anchor-client-v0.3.1) - 2025-07-01
-
-### Added
-
-- Add ledger size fallback for indexer to pick up blobs ([#221](https://github.com/nitro-svm/data-anchor/pull/221))
-
-## [0.3.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.2.0...data-anchor-client-v0.3.0) - 2025-06-26
+## [0.3.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-client-v0.3.0...data-anchor-client-v0.3.1) - 2025-07-01
 
 ### Added
 
-- Add `payer_pubkey` to namespace query ([#203](https://github.com/nitro-svm/data-anchor/pull/203))
-- Rename `BloberClient` to `DataAnchorClient` ([#202](https://github.com/nitro-svm/data-anchor/pull/202))
-- Add API key support to blober client and CLI ([#201](https://github.com/nitro-svm/data-anchor/pull/201))
-- Add new methods to blober client ([#199](https://github.com/nitro-svm/data-anchor/pull/199))
+- Add ledger size fallback for indexer to pick up blobs ([#221](https://github.com/nitro-svm/data-anchor-oss/pull/221))
+
+## [0.3.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-client-v0.2.0...data-anchor-client-v0.3.0) - 2025-06-26
+
+### Added
+
+- Add `payer_pubkey` to namespace query ([#203](https://github.com/nitro-svm/data-anchor-oss/pull/203))
+- Rename `BloberClient` to `DataAnchorClient` ([#202](https://github.com/nitro-svm/data-anchor-oss/pull/202))
+- Add API key support to blober client and CLI ([#201](https://github.com/nitro-svm/data-anchor-oss/pull/201))
+- Add new methods to blober client ([#199](https://github.com/nitro-svm/data-anchor-oss/pull/199))
 
 ### Other
 
-- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor/pull/211))
-- Modularize blober client impls ([#198](https://github.com/nitro-svm/data-anchor/pull/198))
-- Refactor and update docs for indexer API ([#180](https://github.com/nitro-svm/data-anchor/pull/180))
+- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor-oss/pull/211))
+- Modularize blober client impls ([#198](https://github.com/nitro-svm/data-anchor-oss/pull/198))
+- Refactor and update docs for indexer API ([#180](https://github.com/nitro-svm/data-anchor-oss/pull/180))
 
 ## [0.1.7](https://github.com/nitro-svm/nitro-data-module/compare/nitro-da-client-v0.1.6...nitro-da-client-v0.1.7) - 2025-05-30
 

--- a/crates/indexer-api/CHANGELOG.md
+++ b/crates/indexer-api/CHANGELOG.md
@@ -7,72 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2](https://github.com/nitro-svm/data-anchor/compare/data-anchor-api-v0.4.1...data-anchor-api-v0.4.2) - 2025-08-27
+## [0.4.2](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-api-v0.4.1...data-anchor-api-v0.4.2) - 2025-08-27
 
 ### Added
 
-- Add verifier alias instead of pubkey for checkpoint authority ([#345](https://github.com/nitro-svm/data-anchor/pull/345))
+- Add verifier alias instead of pubkey for checkpoint authority ([#345](https://github.com/nitro-svm/data-anchor-oss/pull/345))
 
 ### Other
 
-- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor/pull/344))
+- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor-oss/pull/344))
 
-## [0.4.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-api-v0.4.0...data-anchor-api-v0.4.1) - 2025-08-19
+## [0.4.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-api-v0.4.0...data-anchor-api-v0.4.1) - 2025-08-19
 
 ### Added
 
-- Add foot-gun protection against early blober closing ([#310](https://github.com/nitro-svm/data-anchor/pull/310))
-- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor/pull/308))
-- Add proof request status query ([#305](https://github.com/nitro-svm/data-anchor/pull/305))
-- Add proof posting on-chain after ZK generation ([#303](https://github.com/nitro-svm/data-anchor/pull/303))
-- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor/pull/281))
-- Add initial checkpoint PDA ([#280](https://github.com/nitro-svm/data-anchor/pull/280))
-- Add prover program and proof generation script ([#272](https://github.com/nitro-svm/data-anchor/pull/272))
-- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor/pull/268))
+- Add foot-gun protection against early blober closing ([#310](https://github.com/nitro-svm/data-anchor-oss/pull/310))
+- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor-oss/pull/308))
+- Add proof request status query ([#305](https://github.com/nitro-svm/data-anchor-oss/pull/305))
+- Add proof posting on-chain after ZK generation ([#303](https://github.com/nitro-svm/data-anchor-oss/pull/303))
+- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor-oss/pull/281))
+- Add initial checkpoint PDA ([#280](https://github.com/nitro-svm/data-anchor-oss/pull/280))
+- Add prover program and proof generation script ([#272](https://github.com/nitro-svm/data-anchor-oss/pull/272))
+- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor-oss/pull/268))
 
 ### Other
 
-- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor/pull/302))
-- Use solana_transaction instead of solana_sdk Transaction import ([#299](https://github.com/nitro-svm/data-anchor/pull/299))
-- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor/pull/296))
-- Make time range param consistently optional ([#283](https://github.com/nitro-svm/data-anchor/pull/283))
-- Add health check endpoint ([#267](https://github.com/nitro-svm/data-anchor/pull/267))
+- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor-oss/pull/302))
+- Use solana_transaction instead of solana_sdk Transaction import ([#299](https://github.com/nitro-svm/data-anchor-oss/pull/299))
+- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor-oss/pull/296))
+- Make time range param consistently optional ([#283](https://github.com/nitro-svm/data-anchor-oss/pull/283))
+- Add health check endpoint ([#267](https://github.com/nitro-svm/data-anchor-oss/pull/267))
 
-## [0.4.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-api-v0.3.1...data-anchor-api-v0.4.0) - 2025-07-10
+## [0.4.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-api-v0.3.1...data-anchor-api-v0.4.0) - 2025-07-10
 
 ### Added
 
-- Separate RPC into standalone binary ([#245](https://github.com/nitro-svm/data-anchor/pull/245))
-- Improve PDA management and outputs ([#241](https://github.com/nitro-svm/data-anchor/pull/241))
-- Improve CLI integration ([#234](https://github.com/nitro-svm/data-anchor/pull/234))
+- Separate RPC into standalone binary ([#245](https://github.com/nitro-svm/data-anchor-oss/pull/245))
+- Improve PDA management and outputs ([#241](https://github.com/nitro-svm/data-anchor-oss/pull/241))
+- Improve CLI integration ([#234](https://github.com/nitro-svm/data-anchor-oss/pull/234))
 
 ### Fixed
 
-- Don't run insert network query if no networks found ([#230](https://github.com/nitro-svm/data-anchor/pull/230))
+- Don't run insert network query if no networks found ([#230](https://github.com/nitro-svm/data-anchor-oss/pull/230))
 
 ### Other
 
-- Update indexer API docs ([#231](https://github.com/nitro-svm/data-anchor/pull/231))
-- Simplify API params on indexer RPC ([#228](https://github.com/nitro-svm/data-anchor/pull/228))
+- Update indexer API docs ([#231](https://github.com/nitro-svm/data-anchor-oss/pull/231))
+- Simplify API params on indexer RPC ([#228](https://github.com/nitro-svm/data-anchor-oss/pull/228))
 
-## [0.3.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-api-v0.3.0...data-anchor-api-v0.3.1) - 2025-07-01
-
-### Added
-
-- Add ledger size fallback for indexer to pick up blobs ([#221](https://github.com/nitro-svm/data-anchor/pull/221))
-
-## [0.3.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-api-v0.2.0...data-anchor-api-v0.3.0) - 2025-06-26
+## [0.3.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-api-v0.3.0...data-anchor-api-v0.3.1) - 2025-07-01
 
 ### Added
 
-- Add S3 storage for completeness proofs ([#210](https://github.com/nitro-svm/data-anchor/pull/210))
-- Add `payer_pubkey` to namespace query ([#203](https://github.com/nitro-svm/data-anchor/pull/203))
-- Add more queries to the API ([#182](https://github.com/nitro-svm/data-anchor/pull/182))
+- Add ledger size fallback for indexer to pick up blobs ([#221](https://github.com/nitro-svm/data-anchor-oss/pull/221))
+
+## [0.3.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-api-v0.2.0...data-anchor-api-v0.3.0) - 2025-06-26
+
+### Added
+
+- Add S3 storage for completeness proofs ([#210](https://github.com/nitro-svm/data-anchor-oss/pull/210))
+- Add `payer_pubkey` to namespace query ([#203](https://github.com/nitro-svm/data-anchor-oss/pull/203))
+- Add more queries to the API ([#182](https://github.com/nitro-svm/data-anchor-oss/pull/182))
 
 ### Other
 
-- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor/pull/211))
-- Refactor and update docs for indexer API ([#180](https://github.com/nitro-svm/data-anchor/pull/180))
+- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor-oss/pull/211))
+- Refactor and update docs for indexer API ([#180](https://github.com/nitro-svm/data-anchor-oss/pull/180))
 
 ## [0.1.7](https://github.com/nitro-svm/nitro-data-module/compare/nitro-da-indexer-api-v0.1.6...nitro-da-indexer-api-v0.1.7) - 2025-05-30
 

--- a/crates/proofs/CHANGELOG.md
+++ b/crates/proofs/CHANGELOG.md
@@ -7,45 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2](https://github.com/nitro-svm/data-anchor/compare/data-anchor-proofs-v0.4.1...data-anchor-proofs-v0.4.2) - 2025-08-27
+## [0.4.2](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-proofs-v0.4.1...data-anchor-proofs-v0.4.2) - 2025-08-27
 
 ### Other
 
-- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor/pull/344))
+- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor-oss/pull/344))
 
-## [0.4.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-proofs-v0.4.0...data-anchor-proofs-v0.4.1) - 2025-08-19
+## [0.4.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-proofs-v0.4.0...data-anchor-proofs-v0.4.1) - 2025-08-19
 
 ### Added
 
-- Add initial checkpoint PDA ([#280](https://github.com/nitro-svm/data-anchor/pull/280))
-- Add prover program and proof generation script ([#272](https://github.com/nitro-svm/data-anchor/pull/272))
-- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor/pull/268))
+- Add initial checkpoint PDA ([#280](https://github.com/nitro-svm/data-anchor-oss/pull/280))
+- Add prover program and proof generation script ([#272](https://github.com/nitro-svm/data-anchor-oss/pull/272))
+- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor-oss/pull/268))
 
 ### Other
 
-- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor/pull/302))
-- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor/pull/301))
-- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor/pull/296))
-- Add no change proof test ([#290](https://github.com/nitro-svm/data-anchor/pull/290))
+- Clean up all dependencies ([#302](https://github.com/nitro-svm/data-anchor-oss/pull/302))
+- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor-oss/pull/301))
+- Use solana_pubkey instead of solana_sdk Pubkey import ([#296](https://github.com/nitro-svm/data-anchor-oss/pull/296))
+- Add no change proof test ([#290](https://github.com/nitro-svm/data-anchor-oss/pull/290))
 
-## [0.4.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-proofs-v0.3.1...data-anchor-proofs-v0.4.0) - 2025-07-10
-
-### Other
-
-- Nicer imports of `Hash` ([#262](https://github.com/nitro-svm/data-anchor/pull/262))
-
-## [0.3.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-proofs-v0.3.0...data-anchor-proofs-v0.3.1) - 2025-07-01
+## [0.4.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-proofs-v0.3.1...data-anchor-proofs-v0.4.0) - 2025-07-10
 
 ### Other
 
-- Use import statement instead of qualify ([#218](https://github.com/nitro-svm/data-anchor/pull/218))
+- Nicer imports of `Hash` ([#262](https://github.com/nitro-svm/data-anchor-oss/pull/262))
 
-## [0.3.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-proofs-v0.2.0...data-anchor-proofs-v0.3.0) - 2025-06-26
+## [0.3.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-proofs-v0.3.0...data-anchor-proofs-v0.3.1) - 2025-07-01
 
 ### Other
 
-- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor/pull/211))
-- Update proof docs ([#181](https://github.com/nitro-svm/data-anchor/pull/181))
+- Use import statement instead of qualify ([#218](https://github.com/nitro-svm/data-anchor-oss/pull/218))
+
+## [0.3.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-proofs-v0.2.0...data-anchor-proofs-v0.3.0) - 2025-06-26
+
+### Other
+
+- Upgrade edition, version and formatting ([#211](https://github.com/nitro-svm/data-anchor-oss/pull/211))
+- Update proof docs ([#181](https://github.com/nitro-svm/data-anchor-oss/pull/181))
 
 ## [0.1.7](https://github.com/nitro-svm/nitro-data-module/compare/nitro-da-proofs-v0.1.6...nitro-da-proofs-v0.1.7) - 2025-05-30
 

--- a/crates/proofs/README.md
+++ b/crates/proofs/README.md
@@ -90,9 +90,9 @@ compound_proof.verify(blober_program, blockhash, &[ProofBlob { blob: blob_pubkey
 
 ## Accounts Exclusion Proofs
 
-The [`AccountMerkleTree`](https://github.com/nitro-svm/data-anchor/blob/main/crates/proofs/src/accounts_delta_hash/account_merkle_tree/tree.rs#L33-L38)
+The [`AccountMerkleTree`](https://github.com/nitro-svm/data-anchor-oss/blob/main/crates/proofs/src/accounts_delta_hash/account_merkle_tree/tree.rs#L33-L38)
 is a 16-ary Merkle tree that supports exclusion proofs, which allow callers to verify a given account is not included among its leaves.
-There are [4 types](https://github.com/nitro-svm/data-anchor/blob/main/crates/proofs/src/accounts_delta_hash/exclusion/proof.rs#L12-L20) of exclusion proofs:
+There are [4 types](https://github.com/nitro-svm/data-anchor-oss/blob/main/crates/proofs/src/accounts_delta_hash/exclusion/proof.rs#L12-L20) of exclusion proofs:
 
 - Empty: the tree is empty, so no accounts can be present.
 - Left: an account is smaller than the leftmost leaf and must be to its left.
@@ -100,7 +100,7 @@ There are [4 types](https://github.com/nitro-svm/data-anchor/blob/main/crates/pr
 - Inner: an account has to exist between two adjacent leaves, but no such gap exists.
 
 If each leaf node stored its global index, then exclusion checks would be trivial. Unfortunately, the `AccountMerkleTree` doesn't contain this information,
-so instead we rely on the relative index from [`InclusionProofLevel`](https://github.com/nitro-svm/data-anchor/blob/dcc09b5e8a16e5a287882ccd4126e8cfb82afc23/crates/proofs/src/accounts_delta_hash/inclusion.rs#L11-L18):
+so instead we rely on the relative index from [`InclusionProofLevel`](https://github.com/nitro-svm/data-anchor-oss/blob/dcc09b5e8a16e5a287882ccd4126e8cfb82afc23/crates/proofs/src/accounts_delta_hash/inclusion.rs#L11-L18):
 
 - This represents the node's position within its immediate subtree.
 - It ranges from 0 to `fanout - 1`, where `fanout` is n in an n-ary tree (e.g. 2 in binary trees, 16 in our case).

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -4,9 +4,9 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
 repository.workspace = true
 version.workspace = true
+publish = false
 
 [package.metadata.cargo-udeps.ignore]
 development = ["data-anchor-prover"]

--- a/crates/utils/CHANGELOG.md
+++ b/crates/utils/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2](https://github.com/nitro-svm/data-anchor/compare/data-anchor-utils-v0.4.1...data-anchor-utils-v0.4.2) - 2025-08-27
+## [0.4.2](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-utils-v0.4.1...data-anchor-utils-v0.4.2) - 2025-08-27
 
 ### Added
 
-- Add encoding and compression markers to data ([#337](https://github.com/nitro-svm/data-anchor/pull/337))
+- Add encoding and compression markers to data ([#337](https://github.com/nitro-svm/data-anchor-oss/pull/337))
 
-## [0.4.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-utils-v0.4.0...data-anchor-utils-v0.4.1) - 2025-08-19
+## [0.4.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-utils-v0.4.0...data-anchor-utils-v0.4.1) - 2025-08-19
 
 ### Added
 
-- Add SP1 support for compression ([#326](https://github.com/nitro-svm/data-anchor/pull/326))
-- Add compression support to client ([#315](https://github.com/nitro-svm/data-anchor/pull/315))
-- Add encoding support to client ([#314](https://github.com/nitro-svm/data-anchor/pull/314))
+- Add SP1 support for compression ([#326](https://github.com/nitro-svm/data-anchor-oss/pull/326))
+- Add compression support to client ([#315](https://github.com/nitro-svm/data-anchor-oss/pull/315))
+- Add encoding support to client ([#314](https://github.com/nitro-svm/data-anchor-oss/pull/314))

--- a/examples/examples/cli/README.md
+++ b/examples/examples/cli/README.md
@@ -110,7 +110,7 @@ Below is a high‑level summary of what `cli.sh` does:
 The source code for the CLI and related components is published on [crates.io](https://crates.io), and visible to
 anyone who views them:
 
-- [CLI Documentation](https://docs.rs/data-anchor/latest/data_anchor/)
+- [CLI Documentation](https://docs.rs/data-anchor-oss/latest/data_anchor/)
 - [Client API](https://docs.rs/data-anchor-client/latest/data_anchor_client/)
 - [Blober Program](https://docs.rs/data-anchor-blober/latest/data_anchor_blober/)
 - [Indexer API](https://docs.rs/data-anchor-api/latest/data_anchor_api/)

--- a/examples/examples/client/README.md
+++ b/examples/examples/client/README.md
@@ -97,7 +97,7 @@ just run-client-example <YOUR-API-KEY>
 The source code for the client and related components is published on [crates.io](https://crates.io), and visible to anyone who views them:
 
 - [Client API](https://docs.rs/data-anchor-client/latest/data_anchor_client/)
-- [CLI Documentation](https://docs.rs/data-anchor/latest/data_anchor/)
+- [CLI Documentation](https://docs.rs/data-anchor-oss/latest/data_anchor/)
 - [Blober Program](https://docs.rs/data-anchor-blober/latest/data_anchor_blober/)
 - [Indexer API](https://docs.rs/data-anchor-api/latest/data_anchor_api/)
 - [Proofs API](https://docs.rs/data-anchor-proofs/latest/data_anchor_proofs/)

--- a/programs/programs/blober/CHANGELOG.md
+++ b/programs/programs/blober/CHANGELOG.md
@@ -13,39 +13,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dependency patch
 
-## [0.2.1](https://github.com/nitro-svm/data-anchor/compare/data-anchor-blober-v0.2.0...data-anchor-blober-v0.2.1) - 2025-08-22
+## [0.2.1](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-blober-v0.2.0...data-anchor-blober-v0.2.1) - 2025-08-22
 
 ### Other
 
-- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor/pull/344))
+- Use AccountDeserialize instead of AnchorDeserialize for account data ([#344](https://github.com/nitro-svm/data-anchor-oss/pull/344))
 
-## [0.2.0](https://github.com/nitro-svm/data-anchor/compare/data-anchor-blober-v0.1.7...data-anchor-blober-v0.2.0) - 2025-08-08
+## [0.2.0](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-blober-v0.1.7...data-anchor-blober-v0.2.0) - 2025-08-08
 
 ### Added
 
-- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor/pull/308))
-- Add verifiers and improve checkpointing ([#294](https://github.com/nitro-svm/data-anchor/pull/294))
-- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor/pull/281))
-- Add initial checkpoint PDA ([#280](https://github.com/nitro-svm/data-anchor/pull/280))
-- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor/pull/268))
-- Use vanity address for blober program ([#266](https://github.com/nitro-svm/data-anchor/pull/266))
+- Improve end-to-end test and fix bugs discovered by it ([#308](https://github.com/nitro-svm/data-anchor-oss/pull/308))
+- Add verifiers and improve checkpointing ([#294](https://github.com/nitro-svm/data-anchor-oss/pull/294))
+- Add client and CLI methods for checkpoint handling ([#281](https://github.com/nitro-svm/data-anchor-oss/pull/281))
+- Add initial checkpoint PDA ([#280](https://github.com/nitro-svm/data-anchor-oss/pull/280))
+- Strip down proof system ([#268](https://github.com/nitro-svm/data-anchor-oss/pull/268))
+- Use vanity address for blober program ([#266](https://github.com/nitro-svm/data-anchor-oss/pull/266))
 
 ### Other
 
-- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor/pull/301))
-- Add verifier contracts to workspace deps ([#295](https://github.com/nitro-svm/data-anchor/pull/295))
+- Remove solana_sdk everywhere (almost) ([#301](https://github.com/nitro-svm/data-anchor-oss/pull/301))
+- Add verifier contracts to workspace deps ([#295](https://github.com/nitro-svm/data-anchor-oss/pull/295))
 
-## [0.1.7](https://github.com/nitro-svm/data-anchor/compare/data-anchor-blober-v0.1.6...data-anchor-blober-v0.1.7) - 2025-06-05
+## [0.1.7](https://github.com/nitro-svm/data-anchor-oss/compare/data-anchor-blober-v0.1.6...data-anchor-blober-v0.1.7) - 2025-06-05
 
 ### Fixed
 
-- Properly track all blobers and fix encoding ([#162](https://github.com/nitro-svm/data-anchor/pull/162))
+- Properly track all blobers and fix encoding ([#162](https://github.com/nitro-svm/data-anchor-oss/pull/162))
 
 ## [0.1.6](https://github.com/nitro-svm/nitro-data-module/compare/nitro-da-blober-v0.1.5...nitro-da-blober-v0.1.6) - 2025-05-05
 
 ### Fixed
 
-- Move README for releases  ([#129](https://github.com/nitro-svm/nitro-data-module/pull/129))
+- Move README for releases ([#129](https://github.com/nitro-svm/nitro-data-module/pull/129))
 
 ## [0.1.5](https://github.com/nitro-svm/nitro-data-module/compare/nitro-da-blober-v0.1.4...nitro-da-blober-v0.1.5) - 2025-04-29
 


### PR DESCRIPTION
# Description

This PR bumps the version from 0.4.2 to 0.4.3 across all packages in the workspace. It also updates repository URLs in the changelog files from `data-anchor` to `data-anchor-oss` to reflect the open source repository name.

The README has been updated to improve formatting and fix a documentation link, changing `docs.rs/data-anchor/latest/data_anchor/` to `docs.rs/data-anchor-oss/latest/data_anchor/`.

Additionally, the PR sets `publish = false` for the prover crate to prevent it from being published to crates.io.

## Summary

- [x] Are all new dependencies necessary in `Cargo.toml` necessary?
  - No new dependencies were added, only version numbers were updated